### PR TITLE
Fix (ci): Add missing release-drafter.yml for Calver github workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'v$RESOLVED_VERSION  🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🖊️ Refactors'
+    labels:
+      - 'refactor'
+  - title: '👗 Style'
+    labels:
+      - 'style'
+  - title: '📝 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      # - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      # - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'refactor'
+  patch:
+    labels:
+      # - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'style'
+      - 'docs'
+      - 'documentation'
+  default: patch
+sort-by: title
+template: |
+  ## Changes
+
+  $CHANGES

--- a/generate/definitions/FILES.ps1
+++ b/generate/definitions/FILES.ps1
@@ -2,6 +2,7 @@
 $FILES = @(
     '.github/workflows/ci-master-pr.yml'
     '.github/workflows/ci-release.yml'
+    '.github/release-drafter.yml'
     # '.gitlab-ci.yml'
     'README.md'
 )

--- a/generate/templates/.github/release-drafter.yml.ps1
+++ b/generate/templates/.github/release-drafter.yml.ps1
@@ -1,0 +1,53 @@
+@'
+name-template: 'v$RESOLVED_VERSION  🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🖊️ Refactors'
+    labels:
+      - 'refactor'
+  - title: '👗 Style'
+    labels:
+      - 'style'
+  - title: '📝 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      # - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      # - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'refactor'
+  patch:
+    labels:
+      # - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'style'
+      - 'docs'
+      - 'documentation'
+  default: patch
+sort-by: title
+template: |
+  ## Changes
+
+  $CHANGES
+'@


### PR DESCRIPTION
Fixes `release-drafter.yml` config missing in #1 