### PR TITLE
Feature: Add sops to non-bare variants

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -141,12 +141,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-22-0-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-22-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.22.0-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.22.0-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.22.0-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -401,12 +401,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-21-0-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-21-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.21.0-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.21.0-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.21.0-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -661,12 +661,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-20-4-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-20-4-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.20.4-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.20.4-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.20.4-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -921,12 +921,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-19-7-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-19-7-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.19.7-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.19.7-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.19.7-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1181,12 +1181,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-18-15-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-18-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.18.15-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.18.15-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.18.15-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1441,12 +1441,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-17-17-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.17.17-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.17.17-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.17.17-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1701,12 +1701,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-16-15-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.16.15-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.16.15-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.16.15-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1961,12 +1961,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-15-12-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.15.12-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.15.12-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.15.12-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2221,12 +2221,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-v1-14-10-envsubst-git-jq-kustomize-ssh-alpine-3-8:
+  build-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: v1.14.10-envsubst-git-jq-kustomize-ssh-alpine-3.8
-      # VARIANT_TAG_WITH_REF: v1.14.10-envsubst-git-jq-kustomize-ssh-alpine-3.8-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/v1.14.10-envsubst-git-jq-kustomize-ssh-alpine-3.8
+      VARIANT_TAG: v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
+      # VARIANT_TAG_WITH_REF: v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2353,7 +2353,7 @@ jobs:
 
   # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
   converge-master-and-release-branches:
-    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-ssh-alpine-3-8]
+    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8]
     if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
@@ -2403,7 +2403,7 @@ jobs:
         run: echo ${{ steps.resolve-release-tag.outputs.TAG }}
 
   update-draft-release:
-    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-ssh-alpine-3-8, resolve-release-tag]
+    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, resolve-release-tag]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -2423,7 +2423,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-ssh-alpine-3-8, converge-master-and-release-branches]
+    needs: [build-v1-22-0-alpine-3-8, build-v1-22-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-21-0-alpine-3-8, build-v1-21-0-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-20-4-alpine-3-8, build-v1-20-4-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-19-7-alpine-3-8, build-v1-19-7-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-18-15-alpine-3-8, build-v1-18-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-17-17-alpine-3-8, build-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-16-15-alpine-3-8, build-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-15-12-alpine-3-8, build-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, build-v1-14-10-alpine-3-8, build-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-8, converge-master-and-release-branches]
     # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
     # if: startsWith(github.ref, 'refs/tags/')
     if: github.ref == 'refs/heads/release'

--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ Dockerized `kubectl` with useful tools.
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:v1.22.0-alpine-3.8`, `:latest` | [View](variants/v1.22.0-alpine-3.8 ) |
-| `:v1.22.0-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.22.0-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.21.0-alpine-3.8` | [View](variants/v1.21.0-alpine-3.8 ) |
-| `:v1.21.0-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.21.0-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.20.4-alpine-3.8` | [View](variants/v1.20.4-alpine-3.8 ) |
-| `:v1.20.4-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.20.4-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.19.7-alpine-3.8` | [View](variants/v1.19.7-alpine-3.8 ) |
-| `:v1.19.7-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.19.7-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.18.15-alpine-3.8` | [View](variants/v1.18.15-alpine-3.8 ) |
-| `:v1.18.15-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.18.15-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.17.17-alpine-3.8` | [View](variants/v1.17.17-alpine-3.8 ) |
-| `:v1.17.17-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.17.17-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.16.15-alpine-3.8` | [View](variants/v1.16.15-alpine-3.8 ) |
-| `:v1.16.15-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.16.15-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.15.12-alpine-3.8` | [View](variants/v1.15.12-alpine-3.8 ) |
-| `:v1.15.12-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.15.12-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 | `:v1.14.10-alpine-3.8` | [View](variants/v1.14.10-alpine-3.8 ) |
-| `:v1.14.10-envsubst-git-jq-kustomize-ssh-alpine-3.8` | [View](variants/v1.14.10-envsubst-git-jq-kustomize-ssh-alpine-3.8 ) |
+| `:v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8` | [View](variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8 ) |
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -18,7 +18,7 @@ $local:VARIANTS_MATRIX = @(
             distro_version = '3.8'
             subvariants = @(
                 @{ components = @(); tag_as_latest = if ($v -eq ($local:VARIANTS_PACKAGE_VERSIONS | ? { $_ -match '^v\d+\.\d+\.\d+$' } | Select-Object -First 1 )) { $true } else { $false } }
-                @{ components = @( 'envsubst', 'git', 'jq', 'kustomize', 'ssh' ) }
+                @{ components = @( 'envsubst', 'git', 'jq', 'kustomize', 'sops', 'ssh' ) }
             )
         }
     }

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -57,6 +57,16 @@ RUN apk add --no-cache curl \
 "@
         }
 
+        'sops' {
+
+            @"
+# Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+
+"@
+        }
+
         'ssh' {
             @'
 RUN apk add --no-cache openssh-client

--- a/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.18.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.15/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.19.7-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.19.7/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.20.4-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.21.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]

--- a/variants/v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.22.0-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# kubectl
+RUN apk add --no-cache curl \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/$TARGETPLATFORM/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del curl
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache openssh-client
+
+
+
+ENTRYPOINT [ "/usr/local/bin/kubectl" ]


### PR DESCRIPTION
Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.