### PR TITLE
Enhancement: Add docker-entrypoint.sh

### DIFF
--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -69,6 +69,14 @@ $VARIANTS_SHARED = @{
                     }
                 )
             }
+            'docker-entrypoint.sh' = @{
+                common = $true
+                passes = @(
+                    @{
+                        variables = @{}
+                    }
+                )
+            }
         }
     }
 }

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -4,6 +4,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on `$BUILDPLATFORM, building for `$TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When `$TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/$( $VARIANT['_metadata']['package_version'] )/bin/`$( echo `$TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=`$( wget -qO- "`$BIN_URL.sha512" ) \
@@ -125,6 +128,6 @@ RUN apk add --no-cache --virtual .build-dependencies $PHPIZE_DEPS \
 }
 
 @"
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 "@

--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -1,0 +1,12 @@
+@'
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"
+'@

--- a/variants/v1.14.10-alpine-3.8/Dockerfile
+++ b/variants/v1.14.10-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.14.10/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.14.10-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.14.10-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.15.12-alpine-3.8/Dockerfile
+++ b/variants/v1.15.12-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.15.12/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.15.12-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.15.12-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.16.15-alpine-3.8/Dockerfile
+++ b/variants/v1.16.15-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.15/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.16.15-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.16.15-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.17.17-alpine-3.8/Dockerfile
+++ b/variants/v1.17.17-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.17.17/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.17.17-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.17.17-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.18.20-alpine-3.8/Dockerfile
+++ b/variants/v1.18.20-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.20/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.20/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.18.20-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.18.20-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.20/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.19.16-alpine-3.8/Dockerfile
+++ b/variants/v1.19.16-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.19.16/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.19.16-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.19.16-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.20.15-alpine-3.8/Dockerfile
+++ b/variants/v1.20.15-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.20.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.20.15/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.20.15-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.20.15-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.20.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.21.14-alpine-3.8/Dockerfile
+++ b/variants/v1.21.14-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.14/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.21.14-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.21.14-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.22.14-alpine-3.8/Dockerfile
+++ b/variants/v1.22.14-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.22.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.22.14/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.22.14-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.22.14-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.22.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.22.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.22.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.22.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.22.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.23.11-alpine-3.8/Dockerfile
+++ b/variants/v1.23.11-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.23.11/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.23.11/b
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.23.11-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.23.11-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.23.11-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.23.11-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.23.11/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.23.11-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.23.11-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.24.5-alpine-3.8/Dockerfile
+++ b/variants/v1.24.5-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bi
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.24.5-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.24.5-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.24.5-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.24.5-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.24.5-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.24.5-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.25.1-alpine-3.8/Dockerfile
+++ b/variants/v1.25.1-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -11,4 +14,4 @@ RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bi
     && chmod +x /usr/local/bin/kubectl \
     && sha512sum /usr/local/bin/kubectl | grep "$SHA512"
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.25.1-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.25.1-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/v1.25.1-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v1.25.1-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/Dockerfile
@@ -3,6 +3,9 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 # When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
 RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
     && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
@@ -46,4 +49,4 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client
 
-CMD [ "/usr/local/bin/kubectl" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/v1.25.1-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/v1.25.1-envsubst-git-jq-kustomize-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This allows one to run:
 - `docker run -it <image> --help` to run `kubectl --help`
 - `docker run -it <image> apply` to run `kubectl apply`
 - `docker run -it <image> kubectl apply` to run `kubectl apply`
-  `docker run -it <image> sh` to run `sh`

The downside is that it does add verbosity to the `Dockerfile`.