### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-28-2-alpine-3-15
+      id: prep-1-28-2-alpine-3-15
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.28.2-alpine-3.15"
+        VARIANT="1.28.2-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,52 +102,52 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.28.2-alpine-3.15 - Build (PRs)
+    - name: 1.28.2-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-alpine-3.15
+        context: variants/1.28.2-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.28.2-alpine-3.15 - Build and push (master)
+    - name: 1.28.2-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-alpine-3.15
+        context: variants/1.28.2-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.28.2-alpine-3.15 - Build and push (release)
+    - name: 1.28.2-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-alpine-3.15
+        context: variants/1.28.2-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-alpine-3-15.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -160,7 +160,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -170,45 +170,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-28-2-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -266,7 +266,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-27-6-alpine-3-15
+      id: prep-1-27-6-alpine-3-15
       run: |
         set -e
 
@@ -279,7 +279,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.27.6-alpine-3.15"
+        VARIANT="1.27.6-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -289,51 +289,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.27.6-alpine-3.15 - Build (PRs)
+    - name: 1.27.6-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-alpine-3.15
+        context: variants/1.27.6-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.27.6-alpine-3.15 - Build and push (master)
+    - name: 1.27.6-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-alpine-3.15
+        context: variants/1.27.6-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.27.6-alpine-3.15 - Build and push (release)
+    - name: 1.27.6-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-alpine-3.15
+        context: variants/1.27.6-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -346,7 +346,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -356,45 +356,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-27-6-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -452,7 +452,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-26-9-alpine-3-15
+      id: prep-1-26-9-alpine-3-15
       run: |
         set -e
 
@@ -465,7 +465,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.26.9-alpine-3.15"
+        VARIANT="1.26.9-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -475,51 +475,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.26.9-alpine-3.15 - Build (PRs)
+    - name: 1.26.9-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-alpine-3.15
+        context: variants/1.26.9-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.26.9-alpine-3.15 - Build and push (master)
+    - name: 1.26.9-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-alpine-3.15
+        context: variants/1.26.9-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.26.9-alpine-3.15 - Build and push (release)
+    - name: 1.26.9-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-alpine-3.15
+        context: variants/1.26.9-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -532,7 +532,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -542,45 +542,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-26-9-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -638,7 +638,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-25-14-alpine-3-15
+      id: prep-1-25-14-alpine-3-15
       run: |
         set -e
 
@@ -651,7 +651,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.25.14-alpine-3.15"
+        VARIANT="1.25.14-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -661,51 +661,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.25.14-alpine-3.15 - Build (PRs)
+    - name: 1.25.14-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-alpine-3.15
+        context: variants/1.25.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.25.14-alpine-3.15 - Build and push (master)
+    - name: 1.25.14-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-alpine-3.15
+        context: variants/1.25.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.25.14-alpine-3.15 - Build and push (release)
+    - name: 1.25.14-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-alpine-3.15
+        context: variants/1.25.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -718,7 +718,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -728,45 +728,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-25-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -824,7 +824,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-24-17-alpine-3-15
+      id: prep-1-24-17-alpine-3-15
       run: |
         set -e
 
@@ -837,7 +837,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.24.17-alpine-3.15"
+        VARIANT="1.24.17-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -847,51 +847,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.24.17-alpine-3.15 - Build (PRs)
+    - name: 1.24.17-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-alpine-3.15
+        context: variants/1.24.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.24.17-alpine-3.15 - Build and push (master)
+    - name: 1.24.17-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-alpine-3.15
+        context: variants/1.24.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.24.17-alpine-3.15 - Build and push (release)
+    - name: 1.24.17-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-alpine-3.15
+        context: variants/1.24.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -904,7 +904,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -914,45 +914,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-24-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1010,7 +1010,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-23-17-alpine-3-15
+      id: prep-1-23-17-alpine-3-15
       run: |
         set -e
 
@@ -1023,7 +1023,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.23.17-alpine-3.15"
+        VARIANT="1.23.17-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1033,51 +1033,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.23.17-alpine-3.15 - Build (PRs)
+    - name: 1.23.17-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-alpine-3.15
+        context: variants/1.23.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.23.17-alpine-3.15 - Build and push (master)
+    - name: 1.23.17-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-alpine-3.15
+        context: variants/1.23.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.23.17-alpine-3.15 - Build and push (release)
+    - name: 1.23.17-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-alpine-3.15
+        context: variants/1.23.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -1090,7 +1090,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1100,45 +1100,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-23-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1196,7 +1196,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-22-17-alpine-3-15
+      id: prep-1-22-17-alpine-3-15
       run: |
         set -e
 
@@ -1209,7 +1209,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.22.17-alpine-3.15"
+        VARIANT="1.22.17-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1219,51 +1219,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.22.17-alpine-3.15 - Build (PRs)
+    - name: 1.22.17-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-alpine-3.15
+        context: variants/1.22.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.22.17-alpine-3.15 - Build and push (master)
+    - name: 1.22.17-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-alpine-3.15
+        context: variants/1.22.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.22.17-alpine-3.15 - Build and push (release)
+    - name: 1.22.17-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-alpine-3.15
+        context: variants/1.22.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -1276,7 +1276,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1286,45 +1286,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-22-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1382,7 +1382,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-21-14-alpine-3-15
+      id: prep-1-21-14-alpine-3-15
       run: |
         set -e
 
@@ -1395,7 +1395,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.21.14-alpine-3.15"
+        VARIANT="1.21.14-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1405,51 +1405,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.21.14-alpine-3.15 - Build (PRs)
+    - name: 1.21.14-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-alpine-3.15
+        context: variants/1.21.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.21.14-alpine-3.15 - Build and push (master)
+    - name: 1.21.14-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-alpine-3.15
+        context: variants/1.21.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.21.14-alpine-3.15 - Build and push (release)
+    - name: 1.21.14-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-alpine-3.15
+        context: variants/1.21.14-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -1462,7 +1462,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1472,45 +1472,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-21-14-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1568,7 +1568,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-20-15-alpine-3-15
+      id: prep-1-20-15-alpine-3-15
       run: |
         set -e
 
@@ -1581,7 +1581,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.20.15-alpine-3.15"
+        VARIANT="1.20.15-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1591,51 +1591,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.20.15-alpine-3.15 - Build (PRs)
+    - name: 1.20.15-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-alpine-3.15
+        context: variants/1.20.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.20.15-alpine-3.15 - Build and push (master)
+    - name: 1.20.15-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-alpine-3.15
+        context: variants/1.20.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.20.15-alpine-3.15 - Build and push (release)
+    - name: 1.20.15-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-alpine-3.15
+        context: variants/1.20.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -1648,7 +1648,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1658,45 +1658,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-20-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1754,7 +1754,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-19-16-alpine-3-15
+      id: prep-1-19-16-alpine-3-15
       run: |
         set -e
 
@@ -1767,7 +1767,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.19.16-alpine-3.15"
+        VARIANT="1.19.16-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1777,51 +1777,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.19.16-alpine-3.15 - Build (PRs)
+    - name: 1.19.16-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-alpine-3.15
+        context: variants/1.19.16-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.19.16-alpine-3.15 - Build and push (master)
+    - name: 1.19.16-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-alpine-3.15
+        context: variants/1.19.16-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.19.16-alpine-3.15 - Build and push (release)
+    - name: 1.19.16-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-alpine-3.15
+        context: variants/1.19.16-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -1834,7 +1834,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1844,45 +1844,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-19-16-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1940,7 +1940,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-18-20-alpine-3-15
+      id: prep-1-18-20-alpine-3-15
       run: |
         set -e
 
@@ -1953,7 +1953,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.18.20-alpine-3.15"
+        VARIANT="1.18.20-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1963,51 +1963,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.18.20-alpine-3.15 - Build (PRs)
+    - name: 1.18.20-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-alpine-3.15
+        context: variants/1.18.20-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.18.20-alpine-3.15 - Build and push (master)
+    - name: 1.18.20-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-alpine-3.15
+        context: variants/1.18.20-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.18.20-alpine-3.15 - Build and push (release)
+    - name: 1.18.20-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-alpine-3.15
+        context: variants/1.18.20-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -2020,7 +2020,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2030,45 +2030,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-18-20-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2126,7 +2126,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-17-17-alpine-3-15
+      id: prep-1-17-17-alpine-3-15
       run: |
         set -e
 
@@ -2139,7 +2139,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.17.17-alpine-3.15"
+        VARIANT="1.17.17-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2149,51 +2149,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.17.17-alpine-3.15 - Build (PRs)
+    - name: 1.17.17-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-alpine-3.15
+        context: variants/1.17.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.17.17-alpine-3.15 - Build and push (master)
+    - name: 1.17.17-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-alpine-3.15
+        context: variants/1.17.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.17.17-alpine-3.15 - Build and push (release)
+    - name: 1.17.17-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-alpine-3.15
+        context: variants/1.17.17-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -2206,7 +2206,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2216,45 +2216,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-17-17-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2312,7 +2312,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-16-15-alpine-3-15
+      id: prep-1-16-15-alpine-3-15
       run: |
         set -e
 
@@ -2325,7 +2325,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.16.15-alpine-3.15"
+        VARIANT="1.16.15-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2335,51 +2335,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.16.15-alpine-3.15 - Build (PRs)
+    - name: 1.16.15-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-alpine-3.15
+        context: variants/1.16.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.16.15-alpine-3.15 - Build and push (master)
+    - name: 1.16.15-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-alpine-3.15
+        context: variants/1.16.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.16.15-alpine-3.15 - Build and push (release)
+    - name: 1.16.15-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-alpine-3.15
+        context: variants/1.16.15-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -2392,7 +2392,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2402,45 +2402,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-16-15-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2498,7 +2498,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-15-12-alpine-3-15
+      id: prep-1-15-12-alpine-3-15
       run: |
         set -e
 
@@ -2511,7 +2511,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.15.12-alpine-3.15"
+        VARIANT="1.15.12-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2521,51 +2521,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.15.12-alpine-3.15 - Build (PRs)
+    - name: 1.15.12-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-alpine-3.15
+        context: variants/1.15.12-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.15.12-alpine-3.15 - Build and push (master)
+    - name: 1.15.12-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-alpine-3.15
+        context: variants/1.15.12-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.15.12-alpine-3.15 - Build and push (release)
+    - name: 1.15.12-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-alpine-3.15
+        context: variants/1.15.12-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -2578,7 +2578,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2588,45 +2588,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-15-12-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2684,7 +2684,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-14-10-alpine-3-15
+      id: prep-1-14-10-alpine-3-15
       run: |
         set -e
 
@@ -2697,7 +2697,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.14.10-alpine-3.15"
+        VARIANT="1.14.10-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2707,51 +2707,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.14.10-alpine-3.15 - Build (PRs)
+    - name: 1.14.10-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-alpine-3.15
+        context: variants/1.14.10-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.14.10-alpine-3.15 - Build and push (master)
+    - name: 1.14.10-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-alpine-3.15
+        context: variants/1.14.10-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.14.10-alpine-3.15 - Build and push (release)
+    - name: 1.14.10-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-alpine-3.15
+        context: variants/1.14.10-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
+      id: prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -2764,7 +2764,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
+        VARIANT="1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2774,45 +2774,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
+        context: variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-14-10-envsubst-git-jq-kustomize-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -10,36 +10,36 @@ Dockerized `kubectl` with useful tools.
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v1.28.2-alpine-3.15`, `:latest` | [View](variants/v1.28.2-alpine-3.15) |
-| `:v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.27.6-alpine-3.15` | [View](variants/v1.27.6-alpine-3.15) |
-| `:v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.26.9-alpine-3.15` | [View](variants/v1.26.9-alpine-3.15) |
-| `:v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.25.14-alpine-3.15` | [View](variants/v1.25.14-alpine-3.15) |
-| `:v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.24.17-alpine-3.15` | [View](variants/v1.24.17-alpine-3.15) |
-| `:v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.23.17-alpine-3.15` | [View](variants/v1.23.17-alpine-3.15) |
-| `:v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.22.17-alpine-3.15` | [View](variants/v1.22.17-alpine-3.15) |
-| `:v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.21.14-alpine-3.15` | [View](variants/v1.21.14-alpine-3.15) |
-| `:v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.20.15-alpine-3.15` | [View](variants/v1.20.15-alpine-3.15) |
-| `:v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.19.16-alpine-3.15` | [View](variants/v1.19.16-alpine-3.15) |
-| `:v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.18.20-alpine-3.15` | [View](variants/v1.18.20-alpine-3.15) |
-| `:v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.17.17-alpine-3.15` | [View](variants/v1.17.17-alpine-3.15) |
-| `:v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.16.15-alpine-3.15` | [View](variants/v1.16.15-alpine-3.15) |
-| `:v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.15.12-alpine-3.15` | [View](variants/v1.15.12-alpine-3.15) |
-| `:v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
-| `:v1.14.10-alpine-3.15` | [View](variants/v1.14.10-alpine-3.15) |
-| `:v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/v1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.28.2-alpine-3.15`, `:latest` | [View](variants/1.28.2-alpine-3.15) |
+| `:1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.27.6-alpine-3.15` | [View](variants/1.27.6-alpine-3.15) |
+| `:1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.26.9-alpine-3.15` | [View](variants/1.26.9-alpine-3.15) |
+| `:1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.25.14-alpine-3.15` | [View](variants/1.25.14-alpine-3.15) |
+| `:1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.24.17-alpine-3.15` | [View](variants/1.24.17-alpine-3.15) |
+| `:1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.23.17-alpine-3.15` | [View](variants/1.23.17-alpine-3.15) |
+| `:1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.22.17-alpine-3.15` | [View](variants/1.22.17-alpine-3.15) |
+| `:1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.21.14-alpine-3.15` | [View](variants/1.21.14-alpine-3.15) |
+| `:1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.20.15-alpine-3.15` | [View](variants/1.20.15-alpine-3.15) |
+| `:1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.19.16-alpine-3.15` | [View](variants/1.19.16-alpine-3.15) |
+| `:1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.18.20-alpine-3.15` | [View](variants/1.18.20-alpine-3.15) |
+| `:1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.17.17-alpine-3.15` | [View](variants/1.17.17-alpine-3.15) |
+| `:1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.16.15-alpine-3.15` | [View](variants/1.16.15-alpine-3.15) |
+| `:1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.15.12-alpine-3.15` | [View](variants/1.15.12-alpine-3.15) |
+| `:1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
+| `:1.14.10-alpine-3.15` | [View](variants/1.14.10-alpine-3.15) |
+| `:1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15` | [View](variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15) |
 
 ## Development
 

--- a/Update-Versions.ps1
+++ b/Update-Versions.ps1
@@ -1,4 +1,4 @@
-# This script is to update versions in version.json, create PR(s) for each bumped version, merge PRs, and release
+# This script is to update versions in versions.json, create PR(s) for each bumped version, merge PRs, and release
 # It may be run manually or as a cron
 # Use -WhatIf for dry run
 [CmdletBinding(SupportsShouldProcess)]

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -27,9 +27,9 @@ $VARIANTS = @(
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']
                 }
-                # Docker image tag. E.g. 'v2.3.0.0-alpine-3.6'
+                # Docker image tag. E.g. '1.28.2-alpine-3.15'
                 tag = @(
-                        "v$( $variant['package_version'] )"
+                        $variant['package_version']
                         $subVariant['components'] | ? { $_ }
                         $variant['distro']
                         $variant['distro_version']

--- a/variants/1.14.10-alpine-3.15/Dockerfile
+++ b/variants/1.14.10-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.14.10-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.14.10-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.14.10/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.14.10-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.15.12-alpine-3.15/Dockerfile
+++ b/variants/1.15.12-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.15.12-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.15.12-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.15.12-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.16.15-alpine-3.15/Dockerfile
+++ b/variants/1.16.15-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.16.15-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.16.15-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.16.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.17.17-alpine-3.15/Dockerfile
+++ b/variants/1.17.17-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.17.17-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.17.17-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.17.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.18.20-alpine-3.15/Dockerfile
+++ b/variants/1.18.20-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.20/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.18.20-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.18.20-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.18.20/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.18.20-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.19.16-alpine-3.15/Dockerfile
+++ b/variants/1.19.16-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.19.16-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.19.16-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.19.16-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.20.15-alpine-3.15/Dockerfile
+++ b/variants/1.20.15-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.20.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.20.15-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.20.15-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.20.15/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.20.15-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.21.14-alpine-3.15/Dockerfile
+++ b/variants/1.21.14-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.21.14-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.21.14-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.21.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.22.17-alpine-3.15/Dockerfile
+++ b/variants/1.22.17-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.22.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.22.17-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.22.17-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.22.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.22.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.23.17-alpine-3.15/Dockerfile
+++ b/variants/1.23.17-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.23.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.23.17-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.23.17-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.23.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.23.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.24.17-alpine-3.15/Dockerfile
+++ b/variants/1.24.17-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.24.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.24.17-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.24.17-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.24.17/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.24.17-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.25.14-alpine-3.15/Dockerfile
+++ b/variants/1.25.14-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.25.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.25.14-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.25.14-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.25.14/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.25.14-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.26.9-alpine-3.15/Dockerfile
+++ b/variants/1.26.9-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.26.9/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.26.9-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.26.9-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.26.9/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.26.9-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.27.6-alpine-3.15/Dockerfile
+++ b/variants/1.27.6-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.27.6/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.27.6-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.27.6-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.27.6/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.27.6-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.28.2-alpine-3.15/Dockerfile
+++ b/variants/1.28.2-alpine-3.15/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.28.2/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.28.2-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.28.2-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"

--- a/variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# When $TARGETPLATFORM is linux/arm/v7, strip out the '/v6' or '/v7' from it
+RUN BIN_URL=https://storage.googleapis.com/kubernetes-release/release/v1.28.2/bin/$( echo $TARGETPLATFORM | sed 's@/v[67]$@@' )/kubectl \
+    && SHA512=$( wget -qO- "$BIN_URL.sha512" ) \
+    && wget -qO- "$BIN_URL"  > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && sha512sum /usr/local/bin/kubectl | grep "^$SHA512 " \
+    && kubectl version --client
+
+# From: https://github.com/nginxinc/docker-nginx/blob/1.17.0/stable/alpine/Dockerfile
+# Bring in gettext so we can get `envsubst`, then throw
+# the rest away. To do this, we need to install `gettext`
+# then move `envsubst` out of the way so `gettext` can
+# be deleted completely, then move `envsubst` back.
+RUN apk add --no-cache --virtual .gettext gettext \
+    && mv /usr/bin/envsubst /tmp/ \
+    \
+    && runDeps="$( \
+        scanelf --needed --nobanner /tmp/envsubst \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+    )" \
+    && apk add --no-cache $runDeps \
+    && apk del .gettext \
+    && mv /tmp/envsubst /usr/local/bin/
+
+RUN apk add --no-cache git
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache curl \
+    && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o /usr/local/bin/kustomize \
+    && chmod +x /usr/local/bin/kustomize \
+    && apk del curl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/1.28.2-envsubst-git-jq-kustomize-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- kubectl "$@"
+elif [ $# -gt 0 ] && kubectl "$1" --help > /dev/null 2>&1; then
+    set -- kubectl "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
